### PR TITLE
Fix dependencies resolution for conda installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 *.png
 *.pyc
 *.ipynb_checkpoints
+build/
+*.egg-info
+__pycache__/*

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # Eolabtools
 
-
 Eolabtools allows to use various tools for satellite imagery analysis.
 
-# Detection Orientation Culture
+## Documentation
 
-## Installation procedure
+Full documentation available at [eolabtools.readthedocs.io](https://eolabtools.readthedocs.io).  
+
+## Detection Orientation Culture
+
+### Installation procedure
 
 To install DetectionOrientationCulture, please launch the following commands :
 
@@ -15,7 +18,7 @@ conda activate orcult_env
 pip install opencv-contrib-python "eolabtools[DetecOrCult]"
 ```
 
-## Usage
+### Usage
 
 To obtain the crop orientation in a shapefile format, please use the following command. The method implemented uses the fld library from openCV.
 
@@ -43,11 +46,11 @@ plots are calculated.
 supplied as input.- ``--osm-config`` : Path to the OSM configuration file with tags to keep in binary raster
 
 
-# Night OSM Registration
+## Night OSM Registration
 
 This tool performs night visible data registration based on OSM reference.
 
-## Installation procedure
+### Installation procedure
 
 To install NightOsmRegistration, please launch the following commands :
 
@@ -57,7 +60,7 @@ conda activate nightosm_env
 pip install "eolabtools[NightOsmReg]"
 ```
 
-## Using night_osm_image_registration
+### Using night_osm_image_registration
 
 Use the command ``night_osm_image_registration`` with the following arguments :
 
@@ -80,7 +83,7 @@ Arguments are the following :
 
 - ``--osm-config`` : Path to the OSM configuration file with tags to keep in binary raster
 
-## Using night_osm_vector_registration
+### Using night_osm_vector_registration
 
 Use the command ``night_osm_vector_registration`` with the following arguments :
 
@@ -102,7 +105,7 @@ Arguments are the following :
 
 - ``-n``, ``--name`` : Basename for the output file.
 
-# Sun Map Generation
+## Sun Map Generation
 
 SunMapGeneration generates a map per date with the percentage of sun exposure over the time range, as well as a vector file that
 gives the transition times from shade to sun (and sun to shade) for each pixel at the first date.
@@ -114,7 +117,7 @@ Shadow masks can also be produced at each step.
 If the area of interest is important, the DSM should be divided into tiles beforehand (typically 1km*1km). The list of tiles is
 given as input. The tool will manage the shadow impact on adjacent tiles.
 
-## Installation procedure
+### Installation procedure
 
 
 To install SunMapGeneration, please launch the following commands :
@@ -126,7 +129,7 @@ pip install georastertools
 pip install "eolabtools[SunMapGen]"
 ```
 
-## Usage
+### Usage
 
 To launch SunMapGeneration, please use the following command :
 
@@ -160,14 +163,14 @@ sun_map_generation --digital_surface_model /path_to_input_files/input_files.lst 
 - ``--save_masks`` : To save shadow masks calculated at each time step
 
 
-# Tests
+## Tests
 
 The project comes with a suite functional tests. To run them, 
 launch the command ``pytest tests``. To run a specific test, execute ``pytest tests/test_toolname.py::test_name``.
 The tests perform comparisons between generated files and reference files. 
 
 
-# Documentation generation
+## Documentation generation
 
 To generate the documentation, run in an environment that contains `sphinx_rtd_theme` and `sphinxcontrib.bibtex` : 
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
 # Eolabtools
 
-Eolabtools allows to use various tools for satellite imagery analysis.
-
-## Documentation
-
-Full documentation available at [eolabtools.readthedocs.io](https://eolabtools.readthedocs.io).  
+Eolabtools allows to use various tools for satellite imagery analysis.  
+Full documentation is available at [eolabtools.readthedocs.io](https://eolabtools.readthedocs.io).  
 
 ## Detection Orientation Culture
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Eolabtools allows to use various tools for satellite imagery analysis.
 To install DetectionOrientationCulture, please launch the following commands :
 
 ```bash
-conda create -n orcult_env python=3.12 libgdal=3.11.0 -c conda-forge -c defaults -y
+conda create -n orcult_env -c conda-forge python=3.11 numpy=1.26.4 gdal=3.11.5 pandas=1.5.3 geopandas=0.14.4 rasterio fiona scikit-learn opencv pyyaml
 conda activate orcult_env
-pip install eolabtools[DetecOrCult]
+pip install opencv-contrib-python "eolabtools[DetecOrCult]"
 ```
 
 ## Usage
@@ -52,9 +52,9 @@ This tool performs night visible data registration based on OSM reference.
 To install NightOsmRegistration, please launch the following commands :
 
 ```bash
-conda create -n nightosm_env python=3.12 libgdal=3.11.0 markupsafe -c conda-forge
+conda create -n nightosm_env -c conda-forge python=3.12 gdal=3.11.5 pyrosm rasterio numpy pyogrio geopandas opencv matplotlib pyyaml fiona scikit-image
 conda activate nightosm_env
-pip install eolabtools[NightOsmReg]
+pip install "eolabtools[NightOsmReg]"
 ```
 
 ## Using night_osm_image_registration
@@ -120,10 +120,10 @@ given as input. The tool will manage the shadow impact on adjacent tiles.
 To install SunMapGeneration, please launch the following commands :
 
 ```bash
-conda create -n sunmap_env python=3.12 libgdal=3.5.0 -c conda-forge -c defaults -y
+conda create -n sunmap_env -c conda-forge python=3.12 numpy=1.26.4 gdal=3.9.3 rasterio timezonefinder pytz ephem pyyaml click geopandas kiwisolver matplotlib fiona scipy pyscaffold tqdm
 conda activate sunmap_env
-pip install georastertools --no-binary rasterio
-pip install eolabtools[SunMapGen] --force-reinstall --no-cache-dir
+pip install georastertools
+pip install "eolabtools[SunMapGen]"
 ```
 
 ## Usage

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -17,8 +17,7 @@ To install SunMapGeneration, please launch the following commands :
 
     conda create -n sunmap_env -c conda-forge python=3.12 numpy=1.26.4 gdal=3.9.3 rasterio timezonefinder pytz ephem pyyaml click geopandas kiwisolver matplotlib fiona scipy pyscaffold tqdm
     conda activate sunmap_env
-    pip install georastertools
-    pip install "eolabtools[SunMapGen]"
+    pip install georastertools "eolabtools[SunMapGen]"
 
 
 NightOsmRegistration installation

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -15,10 +15,10 @@ To install SunMapGeneration, please launch the following commands :
 
 .. code-block:: console
 
-    conda create -n sunmap_env python=3.12 libgdal=3.5.0 -c conda-forge -c defaults -y
+    conda create -n sunmap_env -c conda-forge python=3.12 numpy=1.26.4 gdal=3.9.3 rasterio timezonefinder pytz ephem pyyaml click geopandas kiwisolver matplotlib fiona scipy pyscaffold tqdm
     conda activate sunmap_env
-    pip install georastertools --no-binary rasterio
-    pip install eolabtools[SunMapGen] --force-reinstall --no-cache-dir
+    pip install georastertools
+    pip install "eolabtools[SunMapGen]"
 
 
 NightOsmRegistration installation
@@ -28,9 +28,10 @@ To install NightOsmRegistration, please launch the following commands :
 
 .. code-block:: console
 
-    conda create -n nightosm_env python=3.12 libgdal=3.11.0 markupsafe -c conda-forge
+    conda create -n nightosm_env -c conda-forge python=3.12 gdal=3.11.5 pyrosm rasterio numpy pyogrio geopandas opencv matplotlib pyyaml fiona scikit-image
     conda activate nightosm_env
-    pip install eolabtools[NightOsmReg]
+    pip install "eolabtools[NightOsmReg]"
+
 
 DetectionOrientationCulture installation
 =================================
@@ -39,6 +40,6 @@ To install DetectionOrientationCulture, please launch the following commands :
 
 .. code-block:: console
 
-    conda create -n orcult_env python=3.12 libgdal=3.11.0 -c conda-forge -c defaults -y
+    conda create -n orcult_env -c conda-forge python=3.11 numpy=1.26.4 gdal=3.11.5 pandas=1.5.3 geopandas=0.14.4 rasterio fiona scikit-learn opencv pyyaml
     conda activate orcult_env
-    pip install eolabtools[DetecOrCult]
+    pip install opencv-contrib-python "eolabtools[DetecOrCult]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,13 +19,16 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-NightOsmReg = [
+Test = [
     "pytest",
-    "pytest-cov",
+    "pytest-cov"
+]
+NightOsmReg = [
     "pyyaml",
     "numpy",
-    "gdal==3.11.0",
-    "fiona==1.9.6",
+    "pandas<3",
+    "gdal==3.11.5",
+    "fiona",
     "pyogrio",
     "shapely>=2",
     "geopandas",
@@ -36,32 +39,33 @@ NightOsmReg = [
     "matplotlib"
 ]
 SunMapGen = [
-    "pytest",
-    "pytest-cov",
     "pyyaml",
-    "gdal==3.5.0",
-    "numpy<2",
+    "gdal==3.9.3",
+    "georastertools",
+    "rasterio",
+    "numpy==1.26.4",
     "timezonefinder",
-    "ephem"
+    "ephem",
+    "pytz"
 ]
 DetecOrCult = [
-    "pytest",
-    "pytest-cov",
     "pyyaml",
-    "geopandas==0.12.2",
-    "fiona==1.9.6",
-    "rasterio",
-    "gdal==3.11.0",
-    "scikit-learn",
-    "opencv-contrib-python",
-    "rasterstats",
     "numpy==1.26.4",
-    "pandas==1.5.3"
+    "fiona",
+    "rasterio",
+    "gdal==3.11.5",
+    "pandas==1.5.3",
+    "geopandas==0.14.4",
+    "rasterstats",
+    "scikit-learn",
+    "opencv-python",
+    "opencv-contrib-python"
 ]
 
 [project.urls]
 homepage = "https://github.com/CNES/eolabtools"
 repository = "https://github.com/CNES/eolabtools"
+documentation = "https://eolabtools.readthedocs.io"
 
 [project.scripts]
 night_osm_image_registration = "eolabtools.night_osm_registration.register_image:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,9 +19,10 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-Test = [
+Dev = [
     "pytest",
-    "pytest-cov"
+    "pytest-cov",
+    "sphinx"
 ]
 NightOsmReg = [
     "pyyaml",


### PR DESCRIPTION
This PR should fix #9 and address installation issues by providing the correct conda install commands in the docs.
Also added a link to the docs in the README and package metadata.  

These new commands were successfully tested to create working conda env (at least for Linux).  
Notable changes in the dependencies (*should* work but may require testing) :  

### All
- Moved the dev dependencies to a specific deps group since user does not need pytest to run the program (this an issue with `georastertools` installation which includes dev dependencies - testing and docs - in the mandatory deps).

### NighOsmReg
- Bump minor `gdal` version to 3.11.5
- Use soft `fiona` requirement
- Avoid `pandas` 3

### SunMapGen
- Add missing dep `pytz`
- Bump to `gdal` 3.9.3 which is supported by georastertools
- Add `georastertools` dependencies to conda forge available requirements (`click geopandas kiwisolver matplotlib fiona scipy pyscaffold`, etc.)

### DetectOrCult
- Bump minor `gdal` version to 3.11.5
- Bump to latest `geopandas` < 1.0 (i.e. 0.14)
- Pin python 3.11 since conda cannot resolve dependencies for python 3.12 (because of `pandas<2`)
- Use soft `fiona` requirement

This is a minimal working PR, but my refac recommendation for this repo would be to separate packages. Thus you could specify max python version and handle versions conflicts more easily, by avoiding the "optional dependencies group" trick to specify 3 conflicting deps list.

Suggested structure :  
```raw
eolabtools
├── detectorcult
│   ├── environment.yaml
│   ├── pyproject.toml
│   └── src/
├── nightosmreg
│   ├── environment.yaml
│   ├── pyproject.toml
│   └── src/
└── sunmapgen
    ├── environment.yaml
    ├── pyproject.toml
    └── src/
```

The `environment.yaml` is a better way to provide the correct specs to initialize a healthy conda env. It allow to specify conda-forge deps vs pip-only deps, e.g. : 

```yaml
name: sunmapgen
channels:
  - conda-forge
dependencies:
  - python=3.12
  - numpy[version='<2']
  - gdal=3.9
  - rasterio
  - timezonefinder
  - ephem
  - pyyaml
  - click
  - geopandas
  - kiwisolver
  - matplotlib
  - fiona
  - scipy
  - pyscaffold
  - tqdm
  - packaging
  - pytz
  - pip
  - pip:
    - georastertools
```

Same for DetectOrCult (opencv-contrib-python is not available in conda-forge). This would greatly simplify the `conda create` command : 
```bash
conda create --name sunmapgen --file environment.yaml
```

Ideally the docs should also explain how to install without conda (using `venv` and `pip`, or even better with `uv`). With the correct dependencies specification and version limits, a pure pip installation in isolated venv shouldn't generate conflicts and installation issues.